### PR TITLE
Remove dependency on nightly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(trait_alias)]
 #[allow(unused_imports)]
 #[macro_use]
 extern crate serde_derive;


### PR DESCRIPTION
Fixes #1

This changes instances of `XMLIter` bounds to `Iterator<Item=XmlRes>`, which then compiles on stable.