### PR TITLE
Deserialize processing instruction

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -16,6 +16,16 @@ pub struct Deserializer<I: Iterator<Item=XmlRes>> {
     reset_peek_offset: u64,
 }
 
+fn new_reader<I: IntoIterator<Item=XmlRes>>(iter: I) -> itertools::MultiPeek<impl Iterator<Item=XmlRes>> {
+    itertools::multipeek(Box::new(iter.into_iter().filter(|e| match e {
+        &Ok(xml::reader::XmlEvent::ProcessingInstruction { ..}) => {
+            trace!("discarding processing instruction: {:?}", e.as_ref().unwrap());
+            false
+        },
+        _ => true,
+    })))
+}
+
 pub fn from_str<'a, T: Deserialize<'a>>(s: &'a str) -> crate::Result<T> {
     let conf = xml::ParserConfig::new()
         .trim_whitespace(true)
@@ -33,7 +43,7 @@ pub fn from_str<'a, T: Deserialize<'a>>(s: &'a str) -> crate::Result<T> {
         _ => return Err(crate::Error::ExpectedElement)
     }
     let mut deserializer = Deserializer {
-        reader: itertools::multipeek(Box::new(event_reader.into_iter())),
+        reader: new_reader(event_reader),
         depth: 0,
         is_map_value: false,
         is_greedy: true,
@@ -61,7 +71,7 @@ pub fn from_string<'a, T: Deserialize<'a>>(s: String) -> crate::Result<T> {
         _ => return Err(crate::Error::ExpectedElement)
     }
     let mut deserializer = Deserializer {
-        reader: itertools::multipeek(Box::new(event_reader.into_iter())),
+        reader: new_reader(event_reader),
         depth: 0,
         is_map_value: false,
         is_greedy: true,
@@ -73,9 +83,7 @@ pub fn from_string<'a, T: Deserialize<'a>>(s: String) -> crate::Result<T> {
 }
 
 pub fn from_events<'a, T: Deserialize<'a>>(s: &[xml::reader::Result<xml::reader::XmlEvent>]) -> crate::Result<T> {
-    let mut reader = itertools::multipeek(
-        s.into_iter().map(|r| r.to_owned())
-    );
+    let mut reader = new_reader(s.into_iter().map(|r| r.to_owned()));
     if let Ok(xml::reader::XmlEvent::StartDocument { .. }) = reader.peek().ok_or(crate::Error::ExpectedElement)? {
         match reader.next() {
             Some(Ok(xml::reader::XmlEvent::StartDocument {

--- a/src/de.rs
+++ b/src/de.rs
@@ -858,3 +858,51 @@ impl<'de> serde::de::Deserializer<'de> for AttrValueDeserializer {
         struct identifier tuple ignored_any byte_buf
     }
 }
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn deserialize_element_into_struct() {
+        #[derive(Debug, PartialEq, Deserialize)]
+        struct Foo {
+            #[serde(rename = "{urn:foo}foo:bar")]
+            bar: String,
+        }
+
+        assert_eq!(
+            crate::from_str::<Foo>(
+                r#"
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<foo:bar xmlns:foo="urn:foo">baz</foo:bar>
+            "#
+            )
+                .unwrap(),
+            Foo {
+                bar: "baz".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn deserialize_element_with_processing_instruction_into_struct() {
+        #[derive(Debug, PartialEq, Deserialize)]
+        struct Foo {
+            #[serde(rename = "{urn:foo}foo:bar")]
+            bar: String,
+        }
+
+        assert_eq!(
+            crate::from_str::<Foo>(
+                r#"
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<?xml-stylesheet href='foo.xsl' type='text/xsl'?>
+<foo:bar xmlns:foo="urn:foo">baz</foo:bar>
+            "#
+            )
+                .unwrap(),
+            Foo {
+                bar: "baz".to_string()
+            }
+        );
+    }
+}


### PR DESCRIPTION
Thanks for `xml-serde`!

I hit an issue deserializing some XML documents. This document deserializes fine:

```xml
<?xml version="1.0" encoding="utf-8" standalone="yes"?>
<foo:bar xmlns:foo="urn:foo">baz</foo:bar>
```

…but this one does not:

```xml
<?xml version="1.0" encoding="utf-8" standalone="yes"?>
<?xml-stylesheet href='foo.xsl' type='text/xsl'?>
<foo:bar xmlns:foo="urn:foo">baz</foo:bar>
```

XML processing instructions currently have no representation in the `xml-serde` data model, so I added tests to deserialize both documents, and made the second test pass by filtering the `xml::reader::XmlEvent` stream to discard them. This seemed preferable to modifying all the `match` statements to account for the possibility that XML processing instructions might appear at any point in the document, but I'm open to other suggestions too.