### PR TITLE
mark dev dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,13 @@ readme = "README.md"
 
 [dependencies]
 serde = "1"
-serde_derive = "1"
 xml-rs = "0.8"
 hex = "0.4"
 regex = "1"
 log = "0.4"
-pretty_env_logger = "0.4"
 itertools = "0.9"
 once_cell = "1.9"
+
+[dev-dependencies]
+pretty_env_logger = "0.4"
+serde_derive = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#[allow(unused_imports)]
+#[cfg(test)]
 #[macro_use]
 extern crate serde_derive;
 #[macro_use]


### PR DESCRIPTION
This PR moves dependencies that are only used for tests into the `dev-dependencies` section so they aren't passed on to dependents of this crate.